### PR TITLE
Update main retrieval algorithm to mask incidence angle outliers before doing mean normalization

### DIFF
--- a/spicy_snow/retrieval.py
+++ b/spicy_snow/retrieval.py
@@ -121,6 +121,13 @@ def retrieve_snow_depth(area: shapely.geometry.Polygon,
 
     ## Preprocessing Steps
     log.info("Preprocessing Sentinel-1 images")
+
+    #TODO add water mask
+    # ds = ims_water_mask(ds)
+
+    # mask out outliers in incidence angle
+    ds = s1_incidence_angle_masking(ds)
+    
     # subset dataset by flight_dir and platform
     dict_ds = subset_s1_images(ds)
 
@@ -132,12 +139,6 @@ def retrieve_snow_depth(area: shapely.geometry.Polygon,
     
     # recombine subsets
     ds = merge_s1_subsets(dict_ds)
-
-    # add water mask
-    # ds = ims_water_mask(ds)
-
-    # mask out outliers in incidence angle
-    ds = s1_incidence_angle_masking(ds)
 
     ## Snow Index Steps
     log.info("Calculating snow index")


### PR DESCRIPTION
I realized we are doing the orbit geometry mean normalization before we do the incidence angle (70 degree +) masking. I suspect it won't make a big difference to the end result but just to be consistent and avoid those outliers pulling our averaging out of whack this reverses that order.