### PR TITLE
Fix forest cover fraction download for non-CONUS AOIs

### DIFF
--- a/spicy_snow/processing/generate_dataarrays.py
+++ b/spicy_snow/processing/generate_dataarrays.py
@@ -336,8 +336,8 @@ def generate_forest_fraction_dataarray(aoi, ref = None) -> xr.Dataset:
     # first check if in us
     if not within_conus(aoi): 
         log.info(f'AOI outside of CONUS. Using Proba-V datasets')
-        tmp_dir = tempfile.gettempdir()
-        fcf = xr.open_dataarray(download_proba_v(), tmp_dir.joinpath('fcf.tif'))[0]
+        tmp_dir = Path(tempfile.gettempdir())
+        fcf = xr.open_dataarray(download_proba_v(tmp_dir.joinpath('fcf.tif')))[0]
     else: 
         log.info(f'AOI inside of CONUS. NLCD 2021 Forest Cover')
         fcf = get_nlcd(aoi)

--- a/spicy_snow/processing/wet_snow.py
+++ b/spicy_snow/processing/wet_snow.py
@@ -174,9 +174,6 @@ def flag_wet_snow(dataset: xr.Dataset) -> Union[None, xr.Dataset]:
         melt_season = (dataset['time.month'] > 1) & (dataset['time.month'] < 8)
 
         # get images of this relative orbit and in the melt season
-        melt_season = (dataset['time.month'] > 1) & (dataset['time.month'] < 8)
-
-        # get images of this relative orbit and in the melt season
         melt_orbit = (melt_season & (dataset.track == orbit))
 
         # check if there are at least 4 time slices in melt season for this orbit
@@ -224,6 +221,6 @@ def flag_wet_snow(dataset: xr.Dataset) -> Union[None, xr.Dataset]:
     # if less than 50% are wet then keep the save value for wet_snow otherwise set to 1
     dataset['wet_snow'] = dataset['wet_snow'].where(dataset['perma_wet'] < 0.5, 1)
 
-    dataset['wet_snow'].loc[dict(time = ts)] = dataset.sel(time = ts)['wet_snow'].where(dataset.sel(time = ts)['snowcover'] == True, 0)
+    dataset['wet_snow'] = dataset['wet_snow'].where(dataset['snowcover'] == True, 0)
 
     return dataset

--- a/spicy_snow/utils/download.py
+++ b/spicy_snow/utils/download.py
@@ -138,7 +138,10 @@ def decompress(infile, tofile):
 def download_proba_v(out_fp):
     # this is the url from Lievens et al. 2021 paper
     fcf_url = 'https://zenodo.org/record/3939050/files/PROBAV_LC100_global_v3.0.1_2019-nrt_Tree-CoverFraction-layer_EPSG-4326.tif'
-    # download just forest cover fraction to out file
-    fcf_fp = download_url(url = fcf_url, filename = out_fp)
+    # asf_search.download_url takes (url, path, filename) and writes to path/filename;
+    # split out_fp into its parent directory and filename. download_url returns None,
+    # so we return out_fp ourselves.
+    out_fp = Path(out_fp)
+    download_url(url = fcf_url, path = str(out_fp.parent), filename = out_fp.name)
 
-    return fcf_fp
+    return out_fp


### PR DESCRIPTION
## Summary
- `generate_dataarrays.py:340`: misplaced `)` was calling `download_proba_v()` with no args; also wrapped `tempfile.gettempdir()` in `Path(...)` so `.joinpath()` works.
- `utils/download.py:download_proba_v`: was calling `asf_search.download_url(url=..., filename=out_fp)` — but `download_url` requires a `path` (directory) and `filename` is the basename only. Also `download_url` returns `None`, so returning its result broke downstream `xr.open_dataarray`. Split `out_fp` into parent dir + filename and return `out_fp` ourselves.
- `processing/wet_snow.py:227`: a stale `ts` from the inner loop was being used outside both loops, applying the snowcover mask only to the final timestep instead of the whole dataset. Replaced with a dataset-wide `where`.
- `processing/wet_snow.py:174-177`: removed a duplicated `melt_season` computation.

Reproduces from a real run failure on `white_mtns 2024_2025` (Fairbanks, AK — outside CONUS).

## Test plan
- [ ] Re-run the failing case (`white_mtns 2024_2025`) and confirm `generate_forest_fraction_dataarray` returns a valid FCF DataArray.
- [ ] Confirm CONUS-AOI runs are unaffected (NLCD path is untouched).
- [ ] Run existing test suite: `pytest tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)