### PR TITLE
Fix OOM when downloading Proba-V forest cover for non-CONUS AOIs

### DIFF
--- a/spicy_snow/processing/generate_dataarrays.py
+++ b/spicy_snow/processing/generate_dataarrays.py
@@ -17,7 +17,8 @@ import asf_search as asf
 
 # faster reprojection utils
 import rasterio
-from rasterio.warp import reproject, Resampling
+import rioxarray
+from rasterio.warp import reproject, Resampling, transform_bounds
 from rasterio.enums import Resampling as Rsmp
 from rasterio.transform import rowcol
 
@@ -334,11 +335,29 @@ def generate_forest_fraction_dataarray(aoi, ref = None) -> xr.Dataset:
     """
     aoi = validate_aoi(aoi)
     # first check if in us
-    if not within_conus(aoi): 
+    if not within_conus(aoi):
         log.info(f'AOI outside of CONUS. Using Proba-V datasets')
         tmp_dir = Path(tempfile.gettempdir())
-        fcf = xr.open_dataarray(download_proba_v(tmp_dir.joinpath('fcf.tif')))[0]
-    else: 
+        fcf_path = download_proba_v(tmp_dir.joinpath('fcf.tif'))
+        # The Lievens FCF raster is ~3GB global at 100m. Open lazily and
+        # clip to the target area BEFORE any computation, otherwise the
+        # full raster gets loaded into memory and the process is killed.
+        fcf = rioxarray.open_rasterio(fcf_path).squeeze(drop=True)
+        # Build the clip box in EPSG:4326 (FCF native CRS). Prefer the
+        # reprojection target's bounds when available for the tightest crop;
+        # fall back to the AOI bounds.
+        if ref is not None:
+            xmin, ymin, xmax, ymax = transform_bounds(
+                ref.rio.crs, "EPSG:4326", *ref.rio.bounds()
+            )
+        else:
+            xmin, ymin, xmax, ymax = aoi.bounds
+        # Small halo so reproject_match has neighboring pixels available.
+        buf = 0.05  # ~5 km in degrees
+        fcf = fcf.rio.clip_box(
+            minx=xmin - buf, miny=ymin - buf, maxx=xmax + buf, maxy=ymax + buf
+        )
+    else:
         log.info(f'AOI inside of CONUS. NLCD 2021 Forest Cover')
         fcf = get_nlcd(aoi)
 


### PR DESCRIPTION
## Summary
- The Lievens 2021 Proba-V forest-cover-fraction GeoTIFF is a ~3GB global raster at 100m. `xr.open_dataarray(path)[0]` loads the full raster before any clipping, so even tiny AOIs (e.g. Fairbanks ~0.9° × 0.6°) get OOM-killed (`zsh: killed`, no Python traceback) before `reproject_match` runs.
- Switch to lazy `rioxarray.open_rasterio` + `clip_box` to the target area in EPSG:4326 (the FCF native CRS) **before** any reprojection or per-pixel stats.
- Use `ref.rio.bounds()` (reprojected to 4326 via `rasterio.warp.transform_bounds`) when `ref` is provided; fall back to `aoi.bounds`. Small ~0.05° halo so `reproject_match` has surrounding pixels.
- CONUS / NLCD path is untouched.

Follow-up to #79 — same Fairbanks run that exposed the original `download_proba_v` bug then died on memory.

## Test plan
- [ ] Re-run the failing case (`white_mtns 2024_2025`, AOI [-148.3, 65.1, -147.4, 65.7]) and confirm it no longer gets OOM-killed and `fcf` is written into the dataset.
- [ ] Spot-check FCF values are reasonable for Alaska boreal forest (mid-range tree cover).
- [ ] Confirm CONUS-AOI runs are unaffected.
- [ ] `pytest tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)