### PR TITLE
Filter snowcover URLs to .h5 only

### DIFF
--- a/spicy_snow/find_data.py
+++ b/spicy_snow/find_data.py
@@ -40,6 +40,9 @@ def find_snowcover_urls(aoi, start_date = None, stop_date = None, date_list = No
     
     # Flatten all URLs
     snowcover_urls = list(chain.from_iterable([r.data_links() for r in results]))
+    # data_links() also returns .h5.xml metadata sidecars; keep only the HDF5
+    # granules so downstream h5py.File() doesn't choke on the XML files.
+    snowcover_urls = [u for u in snowcover_urls if u.endswith('.h5')]
     
     if date_list is not None:
         date_list = pd.to_datetime(date_list)


### PR DESCRIPTION
## Summary
- `earthaccess.search_data(...).data_links()` returns both the `.h5` VIIRS snowcover granules AND their `.h5.xml` metadata sidecars.
- `download_urls_parallel` happily downloads both. Then `generate_snowcover_dataarray` feeds every file path to `h5py.File()`, which fails on the first XML with `OSError: Unable to synchronously open file (file signature not found)`.
- Filter inside `find_snowcover_urls` so all callers get only HDF5 URLs. Mirrors the s1 URL filter pattern at `retrieval.py:110`.

Follow-up to #79 / #80 — same Fairbanks 2025_2026 run.

## Test plan
- [ ] Re-run `fairbanks 2025_2026` and confirm `generate_snowcover_dataarray` no longer raises.
- [ ] Confirm no `.h5.xml` files appear in fresh snowcover work directories.
- [ ] `pytest tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)