### PR TITLE
Use AOI bounds for FCF clip_box (fix WindowError on some non-CONUS AOIs)

### DIFF
--- a/spicy_snow/processing/generate_dataarrays.py
+++ b/spicy_snow/processing/generate_dataarrays.py
@@ -18,7 +18,7 @@ import asf_search as asf
 # faster reprojection utils
 import rasterio
 import rioxarray
-from rasterio.warp import reproject, Resampling, transform_bounds
+from rasterio.warp import reproject, Resampling
 from rasterio.enums import Resampling as Rsmp
 from rasterio.transform import rowcol
 
@@ -343,16 +343,13 @@ def generate_forest_fraction_dataarray(aoi, ref = None) -> xr.Dataset:
         # clip to the target area BEFORE any computation, otherwise the
         # full raster gets loaded into memory and the process is killed.
         fcf = rioxarray.open_rasterio(fcf_path).squeeze(drop=True)
-        # Build the clip box in EPSG:4326 (FCF native CRS). Prefer the
-        # reprojection target's bounds when available for the tightest crop;
-        # fall back to the AOI bounds.
-        if ref is not None:
-            xmin, ymin, xmax, ymax = transform_bounds(
-                ref.rio.crs, "EPSG:4326", *ref.rio.bounds()
-            )
-        else:
-            xmin, ymin, xmax, ymax = aoi.bounds
+        # Clip in EPSG:4326 (FCF native CRS) using AOI bounds. The ref grid
+        # is also in EPSG:4326 and clipped to aoi.bounds in
+        # generate_reference_grid, so using ref.rio.bounds() here was
+        # equivalent but vulnerable to pixel-edge / projection round-trip
+        # quirks that produced degenerate windows on some AOIs.
         # Small halo so reproject_match has neighboring pixels available.
+        xmin, ymin, xmax, ymax = aoi.bounds
         buf = 0.05  # ~5 km in degrees
         fcf = fcf.rio.clip_box(
             minx=xmin - buf, miny=ymin - buf, maxx=xmax + buf, maxy=ymax + buf


### PR DESCRIPTION
## Summary
- Some non-CONUS AOIs (e.g. white_mtns 2024_2025) fail at \`generate_forest_fraction_dataarray\` with \`rasterio.errors.WindowError: Bounds and transform are inconsistent\` when \`fcf.rio.clip_box(...)\` is called with bounds derived from \`ref.rio.bounds()\`.
- Investigation: \`generate_reference_grid\` already reprojects \`ref\` to EPSG:4326 (line 130) and clips it to \`aoi.bounds\` (line 137). So \`ref.rio.bounds()\` ≈ \`aoi.bounds\` — the "tighter crop" benefit from #80 was illusory.
- Pixel-edge snapping in \`pad_box\` and projection round-tripping in \`reproject\` can produce subtly degenerate bounds that break \`rasterio.windows.from_bounds\`. Bypass the issue by using \`aoi.bounds\` directly.
- Also removes the now-unused \`transform_bounds\` import.

## Test plan
- [x] \`pytest tests/\` — 73/73 pass.
- [ ] Re-run white_mtns 2024_2025 and confirm FCF clip succeeds.
- [ ] Confirm CONUS AOIs still work (NLCD path is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)