### PR TITLE
Fix non-CONUS snow-depth pipeline (FCF + snow_index + VIIRS tile filter)

### DIFF
--- a/spicy_snow/find_data.py
+++ b/spicy_snow/find_data.py
@@ -1,6 +1,7 @@
 """
 Functions to search and download Sentinel-1 RTC images for specific geometries and dates
 """
+import re
 from pathlib import Path
 from itertools import chain
 
@@ -9,6 +10,7 @@ import pandas as pd
 import xarray as xr
 import rioxarray as rxa
 import geopandas as gpd
+from pyproj import Transformer
 
 # opera s1
 import asf_search as asf
@@ -24,6 +26,54 @@ from spicy_snow.hyp3_pipeline import hyp3_pipeline
 
 import logging
 log = logging.getLogger(__name__)
+
+
+# MODIS/VIIRS sinusoidal tile grid constants (10 deg per tile at the equator)
+_VIIRS_TILE_SIZE = 1111950.519667
+_VIIRS_SINU_PROJ = (
+    "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 "
+    "+ellps=WGS84 +datum=WGS84 +units=m +no_defs"
+)
+_VIIRS_TILE_RE = re.compile(r"h(\d{2})v(\d{2})")
+
+
+def _viirs_tiles_for_aoi(aoi_bounds):
+    """Return the set of (h, v) MODIS/VIIRS sinusoidal tiles that an AOI
+    bbox (xmin, ymin, xmax, ymax in EPSG:4326) actually intersects.
+
+    Densely samples the AOI boundary in lat/lon, projects each point to
+    sinusoidal, and reads off the tile indices. This is needed because
+    earthaccess's CMR matching uses each granule's WGS84 polygon, which
+    at high latitudes spans vastly wider longitudes than the tile's real
+    coverage (e.g. h20v01 over Asia matches a Fairbanks bbox).
+    """
+    transformer = Transformer.from_crs("EPSG:4326", _VIIRS_SINU_PROJ, always_xy=True)
+    xmin, ymin, xmax, ymax = aoi_bounds
+    n = 30
+    lons = np.concatenate([
+        np.linspace(xmin, xmax, n), np.linspace(xmin, xmax, n),
+        np.full(n, xmin), np.full(n, xmax),
+    ])
+    lats = np.concatenate([
+        np.full(n, ymin), np.full(n, ymax),
+        np.linspace(ymin, ymax, n), np.linspace(ymin, ymax, n),
+    ])
+    sx, sy = transformer.transform(lons, lats)
+    tiles = set()
+    for x, y in zip(sx, sy):
+        if not (np.isfinite(x) and np.isfinite(y)):
+            continue
+        h = int(np.floor(x / _VIIRS_TILE_SIZE + 18))
+        v = int(np.floor(9 - y / _VIIRS_TILE_SIZE))
+        if 0 <= h < 36 and 0 <= v < 18:
+            tiles.add((h, v))
+    return tiles
+
+
+def _viirs_tile_from_url(url):
+    """Parse 'h##v##' tile ID from a VIIRS granule URL; None if absent."""
+    m = _VIIRS_TILE_RE.search(url)
+    return (int(m.group(1)), int(m.group(2))) if m else None
 
 def find_snowcover_urls(aoi, start_date = None, stop_date = None, date_list = None):
     
@@ -43,7 +93,16 @@ def find_snowcover_urls(aoi, start_date = None, stop_date = None, date_list = No
     # data_links() also returns .h5.xml metadata sidecars; keep only the HDF5
     # granules so downstream h5py.File() doesn't choke on the XML files.
     snowcover_urls = [u for u in snowcover_urls if u.endswith('.h5')]
-    
+    # CMR's WGS84 polygon match over-includes tiles at high latitudes;
+    # restrict to URLs whose (h, v) sinusoidal tile actually covers the AOI.
+    needed_tiles = _viirs_tiles_for_aoi(aoi.bounds)
+    snowcover_urls = [u for u in snowcover_urls if _viirs_tile_from_url(u) in needed_tiles]
+    if not snowcover_urls:
+        raise ValueError(
+            f"No VIIRS snowcover tiles intersect AOI {aoi.bounds}; "
+            f"earthaccess returned no .h5 granules in tiles {needed_tiles}."
+        )
+
     if date_list is not None:
         date_list = pd.to_datetime(date_list)
         # extract dates from filenames

--- a/spicy_snow/processing/generate_dataarrays.py
+++ b/spicy_snow/processing/generate_dataarrays.py
@@ -18,7 +18,7 @@ import asf_search as asf
 # faster reprojection utils
 import rasterio
 import rioxarray
-from rasterio.warp import reproject, Resampling, transform_bounds
+from rasterio.warp import reproject, Resampling
 from rasterio.enums import Resampling as Rsmp
 from rasterio.transform import rowcol
 
@@ -135,7 +135,17 @@ def generate_reference_grid(ref_fp, resolution, aoi):
         ref = sel_1point_da_to_2d_array(ref, aoi.y, aoi.x, crs, transform)
     else:
         ref = ref.rio.clip_box(*aoi.bounds).rio.pad_box(*aoi.bounds)
-    
+
+    # Normalize to north-up (descending y) orientation. Some source S1
+    # bursts (e.g. degenerate single-acquisition tracks at the AOI edge)
+    # produce reference grids with ascending y-coords after reproject,
+    # leaving rio.bounds() returning inverted (bottom > top) values that
+    # break downstream clip_box / reproject_match. Flipping the y axis
+    # and refreshing the cached transform yields a self-consistent grid.
+    if ref.sizes.get('y', 0) > 1 and ref.y.values[0] < ref.y.values[-1]:
+        ref = ref.isel(y=slice(None, None, -1))
+        ref = ref.rio.write_transform(ref.rio.transform(recalc=True))
+
     return ref
 
 def generate_sentinel1_dataarray(
@@ -343,16 +353,15 @@ def generate_forest_fraction_dataarray(aoi, ref = None) -> xr.Dataset:
         # clip to the target area BEFORE any computation, otherwise the
         # full raster gets loaded into memory and the process is killed.
         fcf = rioxarray.open_rasterio(fcf_path).squeeze(drop=True)
-        # Build the clip box in EPSG:4326 (FCF native CRS). Prefer the
-        # reprojection target's bounds when available for the tightest crop;
-        # fall back to the AOI bounds.
-        if ref is not None:
-            xmin, ymin, xmax, ymax = transform_bounds(
-                ref.rio.crs, "EPSG:4326", *ref.rio.bounds()
-            )
-        else:
-            xmin, ymin, xmax, ymax = aoi.bounds
+        # Clip in EPSG:4326 (FCF native CRS) using AOI bounds. The ref
+        # grid is also in EPSG:4326 and clipped to aoi.bounds in
+        # generate_reference_grid, so using ref.rio.bounds() here was
+        # equivalent in principle but vulnerable to grids whose cached
+        # transform disagrees with the y-coords (degenerate single-burst
+        # tracks observed at AOI edges) which yielded inverted bounds
+        # and a degenerate clip window.
         # Small halo so reproject_match has neighboring pixels available.
+        xmin, ymin, xmax, ymax = aoi.bounds
         buf = 0.05  # ~5 km in degrees
         fcf = fcf.rio.clip_box(
             minx=xmin - buf, miny=ymin - buf, maxx=xmax + buf, maxy=ymax + buf

--- a/spicy_snow/processing/snow_index.py
+++ b/spicy_snow/processing/snow_index.py
@@ -35,20 +35,17 @@ def calc_delta_vv(dataset: xr.Dataset) -> Union[None, xr.Dataset]:
     # get all unique relative orbits
     orbits = np.unique(dataset['track'].values)
 
-    for orbit in orbits:
-        
-        # Calculate change in gamma-vv between previous and current time step from the same relative orbit
-        diffvv = dataset['vv'].sel(time = dataset.track == orbit).diff(dim = 'time')
-        
-        # if adding new 
-        if 'deltavv' not in dataset.data_vars:
-            # add delta-gamma-vv as variable to dataset
-            dataset['deltavv'] = diffvv
-        
-        else:
-            # update deltavv times with this. 
-            dataset['deltavv'].loc[dict(time = diffvv.time)] = diffvv
-    
+    # Build per-orbit deltas, concat, then assign once. The previous
+    # in-place `.loc[time=...]` write pattern dies under numpy 2.x +
+    # newer xarray: the first assignment fills missing time slots with a
+    # broadcast-backed read-only buffer, and subsequent orbit writes
+    # raise "Assignment destination is a view".
+    delta_parts = [
+        dataset['vv'].sel(time = dataset.track == orbit).diff(dim = 'time')
+        for orbit in orbits
+    ]
+    dataset['deltavv'] = xr.concat(delta_parts, dim='time').reindex(time=dataset.time)
+
     return dataset
 
 def calc_delta_cross_ratio(dataset: xr.Dataset, A: float = 2) -> Union[None, xr.Dataset]:
@@ -84,23 +81,16 @@ def calc_delta_cross_ratio(dataset: xr.Dataset, A: float = 2) -> Union[None, xr.
 
     # get all unique relative orbits
     orbits = np.unique(dataset['track'].values)
-    
-    # Identify previous image from the same relative orbit (6, 12, 18, or 24 days ago)
-    for orbit in orbits:
 
-        # Calculate change in gamma-cr between previous and current time step
-        diffCR = gamma_cr.sel(time = dataset.track == orbit).diff(dim = 'time')
-        
-        # add delta-gamma-cr as band to dataset
-        # if adding new 
-        if 'deltaCR' not in dataset.data_vars:
-            # add delta-gamma-CR as new variable to dataset
-            dataset['deltaCR'] = diffCR
-        
-        else:
-            # update deltaCR times with this. 
-            dataset['deltaCR'].loc[dict(time = diffCR.time)] = diffCR
-    
+    # Build per-orbit deltas, concat, then assign once. See calc_delta_vv
+    # above for why the previous in-place `.loc[time=...]` pattern fails
+    # under numpy 2.x + newer xarray.
+    delta_parts = [
+        gamma_cr.sel(time = dataset.track == orbit).diff(dim = 'time')
+        for orbit in orbits
+    ]
+    dataset['deltaCR'] = xr.concat(delta_parts, dim='time').reindex(time=dataset.time)
+
     return dataset
 
 def calc_delta_gamma(dataset: xr.Dataset, B: float = 0.5) -> Union[None, xr.Dataset]:

--- a/tests/test_find_data.py
+++ b/tests/test_find_data.py
@@ -36,25 +36,32 @@ def example_results_df():
 # -----------------------------
 @patch("spicy_snow.find_data.earthaccess.search_data")
 def test_find_snowcover_urls(mock_search, example_aoi):
-    # NSIDC's data_links() returns both .h5 granules and .h5.xml metadata
-    # sidecars; find_snowcover_urls should drop the sidecars.
+    # earthaccess data_links() returns:
+    #  - .h5 granules in the correct sinusoidal tile (kept)
+    #  - .h5.xml metadata sidecars (dropped)
+    #  - .h5 granules in tiles that don't actually cover the AOI (dropped) -
+    #    CMR over-includes these at high latitudes due to the sinusoidal
+    #    projection's WGS84 polygon shape.
+    # The Colorado AOI [-110, 40, -105, 45] sits in MODIS/VIIRS tile h10v04;
+    # h20v06 is over Africa/Indian Ocean and should be filtered out.
     mock_result = MagicMock()
     mock_result.data_links.return_value = [
-        'https://example.com/test.A2025001.v1.h5',
-        'https://example.com/test.A2025001.v1.h5.xml',
-        'https://example.com/test.A2025002.v1.h5',
+        'https://example.com/VJ110A1F.A2025001.h10v04.002.20250021.h5',
+        'https://example.com/VJ110A1F.A2025001.h10v04.002.20250021.h5.xml',
+        'https://example.com/VJ110A1F.A2025001.h20v06.002.20250021.h5',
+        'https://example.com/VJ110A1F.A2025002.h10v04.002.20250022.h5',
     ]
     mock_search.return_value = [mock_result]
 
     urls = fd.find_snowcover_urls(example_aoi, "2025-01-01", "2025-01-02")
     assert urls == [
-        'https://example.com/test.A2025001.v1.h5',
-        'https://example.com/test.A2025002.v1.h5',
+        'https://example.com/VJ110A1F.A2025001.h10v04.002.20250021.h5',
+        'https://example.com/VJ110A1F.A2025002.h10v04.002.20250022.h5',
     ]
 
     # Test filtering by date_list
     urls_filtered = fd.find_snowcover_urls(example_aoi, "2025-01-01", "2025-01-02", date_list=["2025-01-01"])
-    assert urls_filtered == ['https://example.com/test.A2025001.v1.h5']
+    assert urls_filtered == ['https://example.com/VJ110A1F.A2025001.h10v04.002.20250021.h5']
 
 # -----------------------------
 # Tests for get_urls_from_asf_search


### PR DESCRIPTION
Replaces the closed PRs #83 and #84 with a clean two-commit branch — no \`.load()\`/\`.copy(deep=True)\` bandaids from earlier exploration.

Verified end-to-end on Alaska AOIs (fairbanks + white_mtns, both 2024-25 and 2025-26 winters): all four runs complete, snowcover reads realistic 0-100% values, snow_depth peaks 4-5m where expected.

## Commits

### 1. \`88777fe\` — xarray new version fix on view vs copy + FCF aoi bounds
- **\`generate_dataarrays.py:generate_reference_grid\`**: normalize y-orientation. Some source S1 bursts (degenerate single-acquisition tracks at AOI edges) produce reference grids with ascending y-coords after reproject, leaving \`rio.bounds()\` returning inverted (bottom > top) values that break downstream \`clip_box\`/\`reproject_match\`. Flip the y axis and refresh the cached transform.
- **\`generate_dataarrays.py:generate_forest_fraction_dataarray\`**: use \`aoi.bounds\` for the FCF \`clip_box\` instead of \`transform_bounds(ref.rio.crs, ..., *ref.rio.bounds())\`. The ref grid is already in EPSG:4326 and clipped to \`aoi.bounds\`, so this is equivalent in principle but bypasses any residual transform/coord inconsistency.
- **\`snow_index.py:calc_delta_vv\` and \`calc_delta_cross_ratio\`**: replace per-orbit in-place \`.loc[time=...]\` writes with build-list + \`xr.concat\` + \`reindex\` + single assignment. Under numpy 2.x + newer xarray, the first in-place assignment fills missing time slots with a broadcast-backed read-only buffer, and subsequent orbit writes raise "Assignment destination is a view".

### 2. \`76b9f40\` — filter VIIRS snowcover URLs to tiles that actually intersect AOI
- **\`find_data.py:find_snowcover_urls\`**: added \`_viirs_tiles_for_aoi\` and \`_viirs_tile_from_url\` helpers. earthaccess's CMR matches each granule's WGS84 polygon, but at high latitudes VIIRS sinusoidal tiles have polygons spanning enormously wider longitudes than their actual coverage. For a Fairbanks AOI, CMR returned h11v02 (correct) plus h10v02, h20v01 (Asia), and h23v02 (Pacific). \`generate_snowcover_dataarray\` then mosaicked all four — the resulting sparse raster sampled mostly-fill at the Fairbanks AOI, yielding \`snowcover = 0\` everywhere.
- Filter projects AOI bbox edges to sinusoidal, computes the (h, v) tiles they touch, drops everything else. Verified against ground-truth: Fairbanks AOI → \`{(11, 2)}\` only.
- Also fixes the white_mtns 2024-25 \`snow_depth = 0\` regression as a side effect (starving snowcover was the upstream cause; not a snow-index bug).
- \`tests/test_find_data.py\` mock updated to use realistic VJ110A1F URLs (with \`h##v##\`) and asserts a non-intersecting tile gets filtered out.

## Test plan
- [x] \`pytest tests/\` — 73/73 pass.
- [x] Real-data run on 4 winters (fairbanks + white_mtns × 2024-25 + 2025-26): all complete, all produce non-zero snow_depth where snowcover indicates snow.
- [x] white_mtns 2024-25 snowcover AOI-mean peak: 1.0 (was 0.145), snow_depth max: 4.56 m (was 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)