### PR TITLE
Bump asf_search CMR_TIMEOUT to 120s

### DIFF
--- a/spicy_snow/find_data.py
+++ b/spicy_snow/find_data.py
@@ -15,6 +15,10 @@ from pyproj import Transformer
 # opera s1
 import asf_search as asf
 from asf_search import download_url
+from asf_search.constants import INTERNAL as _ASF_INTERNAL
+# Default CMR_TIMEOUT is 30s, which is intermittently too short for
+# long high-latitude winter queries that return 600+ S1 granules.
+_ASF_INTERNAL.CMR_TIMEOUT = 120
 # viirs snow cover
 import earthaccess
 from tqdm import tqdm


### PR DESCRIPTION
Follow-up to #85. Got squeezed out of that merge.

## Summary
- Real runs intermittently fail with \`Connection Error (Timeout): CMR took too long to respond. Set asf constant 'asf_search.constants.INTERNAL.CMR_TIMEOUT' to increase. (timeout=30)\` on long high-latitude winter queries that return 600+ S1 granules.
- Bump \`CMR_TIMEOUT\` to 120s at module load in \`find_data.py\`. If CMR is genuinely slower than that, retries wouldn't help.

## Test plan
- [x] \`pytest tests/\` — 73/73 pass.
- [x] Verified import-time side effect: \`from asf_search.constants import INTERNAL; INTERNAL.CMR_TIMEOUT == 120\` after \`import spicy_snow.find_data\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)