### PR TITLE
Filter out .h5.xml metadata sidecars from VIIRS snowcover URLs

### DIFF
--- a/spicy_snow/retrieval.py
+++ b/spicy_snow/retrieval.py
@@ -126,6 +126,8 @@ def retrieve_snow_depth(aoi: shapely.geometry.Polygon,
 
     # download viirs snow cover fraction for each sentinel 1 overpass date
     snowcover_urls = find_snowcover_urls(start_date = dates[0], stop_date = dates[1], date_list = ds.time.dt.date, aoi = aoi)
+    # recent granules' data_links include .h5.xml metadata sidecars; keep only the .h5 data files
+    snowcover_urls = [u for u in snowcover_urls if u.endswith('.h5')]
     snowcover_fps = download_urls_parallel(snowcover_urls, work_dir.joinpath('snowcover'))
 
     # generate snow cover dataset


### PR DESCRIPTION
## Problem

Recent VIIRS `VJ110A1F` granules return `.h5.xml` metadata sidecars in their `earthaccess` `data_links()`, alongside the real `.h5` data files, e.g.:

```
VJ110A1F.A2026016.h09v05.002.2026017073829.h5       # 2.35 MB HDF5 data
VJ110A1F.A2026016.h09v05.002.2026017073829.h5.xml   # 2.4 KB XML metadata
```

`download_urls_parallel` downloaded both, and `generate_snowcover_dataarray` then called `h5py.File()` on every downloaded path — including the `.h5.xml`, which is XML, not HDF5. That raises:

```
OSError: Unable to synchronously open file (file signature not found)
```

and fails any `retrieve_snow_depth` call whose date range includes recent granules (older granules' link lists don't include the sidecars, so only recent/current-water-year runs hit it). The error text is identical to a truncated-HDF5 read, which makes it easy to misdiagnose as transient I/O.

## Fix

Keep only `.h5` URLs before download, mirroring the existing Sentinel-1 URL filter (`u.endswith(('_VV.tif', '_VH.tif', '_mask.tif'))`):

```python
snowcover_urls = [u for u in snowcover_urls if u.endswith('.h5')]
```

## Verification

With this filter, a previously-failing batch (5 sites × WY2026, which had failed every attempt at the `.h5.xml` open) completed cleanly — all snow-depth netCDFs written, values physical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)