### PR TITLE
Fix VH coverage collapse from y-flipped mosaic reference grid

### DIFF
--- a/spicy_snow/retrieval.py
+++ b/spicy_snow/retrieval.py
@@ -18,7 +18,8 @@ sys.path.append(expanduser('../'))
 # import functions for downloading
 from spicy_snow.find_data import get_sentinel1_urls, find_snowcover_urls
 from spicy_snow.processing.generate_dataarrays import generate_sentinel1_dataarray,\
-    generate_snowcover_dataarray, generate_forest_fraction_dataarray, convert_snowcover_dates_to_s1_overpasses
+    generate_snowcover_dataarray, generate_forest_fraction_dataarray, convert_snowcover_dates_to_s1_overpasses,\
+    generate_reference_grid
 
 # import functions for pre-processing
 from spicy_snow.processing.s1_preprocessing import s1_orbit_averaging, s1_clip_outliers, ims_water_mask, amplitude_to_dB
@@ -113,13 +114,19 @@ def retrieve_snow_depth(aoi: shapely.geometry.Polygon,
 
     # generate dataset and start to save s1 data vars. Use zarr to reduce memory load for big arrays
     ds = xr.Dataset()
-    ds['vv'] = generate_sentinel1_dataarray(s1_fps, aoi, pol = 'VV', resolution = resolution)
 
-    # grab spatial reference from first time step of VV
+    # build one clean full-AOI reference grid and use it for BOTH pols. Reusing
+    # ds['vv'].isel(time=0) as the VH reference corrupts VH: the
+    # combine_close_images output has a flipped-y coords/transform mismatch that
+    # misplaces the VH reproject grid and silently discards most of the swath.
+    vv_fps = sorted(f for f in s1_fps if f.stem.lower().endswith('vv'))
+    ref_grid = generate_reference_grid(vv_fps[0], resolution, aoi)
+
+    ds['vv'] = generate_sentinel1_dataarray(s1_fps, aoi, pol = 'VV', ref = ref_grid)
+    ds['vh'] = generate_sentinel1_dataarray(s1_fps, aoi, pol = 'VH', ref = ref_grid)
+
+    # grab spatial reference for later resampling of ancillary layers
     spatial_reference = ds['vv'].isel(time = 0)
-
-    # repeat combining and spatial resampling for VH
-    ds['vh'] = generate_sentinel1_dataarray(s1_fps, aoi, pol = 'VH', ref = spatial_reference)
     
     # next VIIRS snowcover #
     log.info("Downloading VIIRS snowcover data")

--- a/spicy_snow/utils/raster.py
+++ b/spicy_snow/utils/raster.py
@@ -32,7 +32,6 @@ def mosaic_group(sub):
     # sub is a DataArray with 'time' dimension
     merged = reduce(lambda a, b: a.combine_first(b), [sub.isel(time=i) for i in range(sub.sizes['time'])])
     merged = merged.expand_dims(time=[pd.to_datetime(sub['time']).mean()])  # assign average time
-    merged = merged.dropna('x', how = 'all').dropna('y', how = 'all')
     return merged
 
 def combine_close_images(da, time_tol = pd.Timedelta('2min')):


### PR DESCRIPTION
## Problem

On any AOI spanning more than one Sentinel-1 relative orbit, the VH channel
collapses to a fraction of the AOI on every acquisition, which in turn collapses
retrieved snow extent. VV is unaffected, so it is easy to miss.

## Root cause

`mosaic_group` (`utils/raster.py`) trims each per-pass mosaic with
`.dropna('x'/'y', how='all')`. Different tracks have different footprints, so the
groups end up with different extents. When `combine_close_images` concatenates
them, the outer-join alignment **re-sorts the y coordinate ascending** — flipping
the array relative to its north-down geotransform and corrupting the pixel
spacing.

`retrieve_snow_depth` then reuses `ds['vv'].isel(time=0)` (one of these flipped
mosaics) as the **VH reproject reference**, so the VH destination grid is
misplaced and most of every swath is reprojected into nothing.

## Fix

- `raster.py`: drop the `dropna` trim so every group stays on the full reference
  grid and the `combine_close_images` concat is a no-op alignment (root fix).
- `retrieval.py`: build one clean full-AOI reference grid with
  `generate_reference_grid` and use it for **both** VV and VH, instead of the
  fragile `isel(time=0)` reference.

## Verification

End-to-end on a multi-track basin (gunnison, WY2023): VH coverage 21% -> 100%,
retrieved snow extent 20% -> 99%, and the peak shifts to a physically sensible
date. Single-track AOIs were unaffected (no heterogeneous-extent concat), which
is why this went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)