### PR TITLE
Fix VIIRS sinusoidal CRS: authalic sphere, not WGS84 ellipsoid

### DIFF
--- a/spicy_snow/processing/generate_dataarrays.py
+++ b/spicy_snow/processing/generate_dataarrays.py
@@ -301,10 +301,10 @@ def generate_snowcover_dataarray(snowcover_fps, ref = None):
     snowcover_da = xr.concat(daily_arrays, dim='time').sortby('time')
     snowcover_da.name = 'snowcover'
 
-    # convert from NASA's sinusoidal project
-    # proj string comes from Table 3 of
-    # https://nsidc.org/sites/default/files/documents/user-guide/multi_vnp10a1f-v002-userguide.pdf
-    src_crs = "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"
+    # convert from NASA's sinusoidal projection. Grid is on the MODIS/VIIRS
+    # authalic SPHERE (R=6371007.181 m), NOT WGS84 -- using +ellps=WGS84 here
+    # offsets the reproject ~18 km north at mid-latitudes (meridian-arc vs y=R*lat).
+    src_crs = "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6371007.181 +b=6371007.181 +units=m +no_defs"
     snowcover_da = snowcover_da.rio.write_crs(src_crs)
 
     if ref is not None:


### PR DESCRIPTION
## Problem

`generate_snowcover_dataarray` declared the VNP10A1F source sinusoidal grid with `+ellps=WGS84`, but the MODIS/VIIRS sinusoidal grid is defined on the authalic **sphere R=6371007.181 m** — which the granule's own `StructMetadata` confirms (`Projection=HE5_GCTP_SNSOID`, `ProjParams=(6371007.181, ...)`).

Modern PROJ honors `+ellps` and switches to the *ellipsoidal* sinusoidal (meridian-arc) inverse, which diverges from the sphere's `y=R·φ` by **~18 km north at mid-latitudes**. This shifted the snowcover/watermask layers north, which in turn misplaced the `snow_index` snow-free reset (`snow_index.py`) and the wet-snow masking.

## Fix

One line: declare the source CRS on the sphere the grid was actually built on.

```diff
-src_crs = "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"
+src_crs = "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6371007.181 +b=6371007.181 +units=m +no_defs"
```

## Verification

Confirmed against three independent references over the gunnison / Blue Mesa AOI (38°N):

| check | before (WGS84) | after (sphere) |
|---|---|---|
| snow vs Copernicus DEM elevation (corr) | +0.17 | +0.60 |
| north offset vs ESA WorldCover water | −18.3 km | −4.5 km |
| overlap with Blue Mesa Reservoir | 0.00 | 0.60 |

The "before" inland-water flag (237) sits ~18 km north of the actual reservoir (zero overlap); the fix lands it on the lake. The residual ~4.5 km is morphology (VIIRS 375 m resolves only the open-water core vs ESA 10 m capturing the full reservoir arms), not georeferencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)